### PR TITLE
Fix assertions in test suite

### DIFF
--- a/test_main.m
+++ b/test_main.m
@@ -16,4 +16,4 @@ end
 
 A = blkdiag(ones(5),ones(5)); A(1,10) = 1; A(10,1) = 1; A(5,6) = 1; A(6,5) = 1;
 [p1,p2] = metispart(sparse(A));
-assert(all(p1-[1,2,3,4,5] == 0))
+assert(all(p1-[1,2,3,4,5] == 0) || all(p1-[6,7,8,9,10] == 0))

--- a/test_main.m
+++ b/test_main.m
@@ -16,4 +16,7 @@ end
 
 A = blkdiag(ones(5),ones(5)); A(1,10) = 1; A(10,1) = 1; A(5,6) = 1; A(6,5) = 1;
 [p1,p2] = metispart(sparse(A));
-assert(all(p1-[1,2,3,4,5] == 0) || all(p1-[6,7,8,9,10] == 0))
+e1 = [1,2,3,4,5];
+e2 = [6,7,8,9,10];
+assert(all(p1-e1 == 0) || all(p1-e2 == 0))
+assert(all(p2-e1 == 0) || all(p2-e2 == 0))


### PR DESCRIPTION
Hello,

I've tried using your *.mex file in configuration:
- OSX El Captain
- MATLAB 2015b 64-bit
- cmake version 3.4.1
- metis 5.0.2 and 5.1.0

I've followed your instructions, mex file has compiled fine, although test suite raised assertion error (in lines edited).

If I understand correctly, partitions `[p1, p2]` and `[p2, p1]` are equivalent, so I generalised an assert statement. I'm not sure about what caused discrepancy. Unfortunately, Metis 5.0-pre2 is not available on original share now, so I cannot recreate original behaviour completely.

Could you please follow up on this? Also, please correct me if anything I said is not true. I'm fairly new to this field of study and may make some basic mistakes.

Regards,
Lukasz
